### PR TITLE
Alternative way to add nodes in the editor

### DIFF
--- a/addons/control++/circle_container.gd
+++ b/addons/control++/circle_container.gd
@@ -1,7 +1,5 @@
 tool
 extends Container
-class_name CircleContainer, "res://addons/control++/CircleContainer.svg"
-
 
 export(float) var radius := 40.0 setget _set_radius
 export(float) var start_degrees := 0.0 setget _set_start_degrees

--- a/addons/control++/control++.gd
+++ b/addons/control++/control++.gd
@@ -1,10 +1,11 @@
 tool
 extends EditorPlugin
 
-
 func _enter_tree() -> void:
-	pass
-
+	add_custom_type("CircleContainer", "Container", preload("res://addons/control++/circle_container.gd"), preload("res://addons/control++/CircleContainer.svg"))
+	add_custom_type("FixedGrid", "GridContainer", preload("res://addons/control++/fixed_grid.gd"), preload("res://addons/control++/FixedGrid.svg"))
+	add_custom_type("HBoxContainer++", "HBoxContainer", preload("res://addons/control++/h_box_container++.gd"), null)
+	add_custom_type("VBoxContainer++", "VBoxContainer", preload("res://addons/control++/v_box_container++.gd"), null)
 
 func _exit_tree() -> void:
 	pass

--- a/addons/control++/fixed_grid.gd
+++ b/addons/control++/fixed_grid.gd
@@ -1,7 +1,5 @@
 tool
 extends Container
-class_name FixedGrid, "res://addons/control++/FixedGrid.svg"
-
 
 export(int, 1, 2_147_483_647) var columns := 1 setget _set_columns
 export(int, 1, 2_147_483_647) var rows := 1 setget _set_rows

--- a/addons/control++/h_box_container++.gd
+++ b/addons/control++/h_box_container++.gd
@@ -1,7 +1,5 @@
 tool
 extends HBoxContainer
-class_name HBoxContainerPlus
-
 
 export(int) var step := 0 setget _set_step
 export(float) var child_rotation := 0.0 setget _set_child_rotation

--- a/addons/control++/v_box_container++.gd
+++ b/addons/control++/v_box_container++.gd
@@ -1,7 +1,5 @@
 tool
 extends VBoxContainer
-class_name VBoxContainerPlus
-
 
 export(int) var step := 0 setget _set_step
 export(float) var child_rotation := 0.0 setget _set_child_rotation


### PR DESCRIPTION
Basically nodes will be registered thru plugin script, without class names in each script, pretty useless, but it looks a lot cleaner because now, script name won't show in the node's name

![image](https://user-images.githubusercontent.com/53514993/139345978-27ec08b6-6444-4a03-aba3-5e804c661637.png)
